### PR TITLE
autoscale bottom with null values

### DIFF
--- a/harry.js
+++ b/harry.js
@@ -390,7 +390,7 @@ harry=(function(o){
 			ds.lab.push(l);
 			ds.sum+=v;
 			if(v>ds.max) ds.max=v;
-			if(v<ds.min) ds.min=v;
+			if(v && v<ds.min) ds.min=v;
 		}
 		ds.len=ds.val.length;
 		ds.avg=ds.len ? ds.sum/ds.len : 0;


### PR DESCRIPTION
In a dataset with null values, null was selected as the lowest value so autoscale bottom wasn't working.
